### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Just a simple integration for [Phosphor Icons](https://phosphoricons.com) in [Nu
 
    ```bash
    # Using pnpm
-   pnpm add -D nuxt-phosphor-icons
+   npx nuxi@latest module add nuxt-phosphor-icons
 
    # Using yarn
-   yarn add --dev nuxt-phosphor-icons
+   npx nuxi@latest module add nuxt-phosphor-icons
 
    # Using npm
-   npm install --save-dev nuxt-phosphor-icons
+   npx nuxi@latest module add nuxt-phosphor-icons
    ```
 
 2. Add `nuxt-phosphor-icons` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -15,15 +15,7 @@ Just a simple integration for [Phosphor Icons](https://phosphoricons.com) in [Nu
 1. Add `nuxt-phosphor-icons` dependency to your project
 
    ```bash
-   # Using pnpm
    npx nuxi@latest module add nuxt-phosphor-icons
-
-   # Using yarn
-   npx nuxi@latest module add nuxt-phosphor-icons
-
-   # Using npm
-   npx nuxi@latest module add nuxt-phosphor-icons
-   ```
 
 2. Add `nuxt-phosphor-icons` to the `modules` section of `nuxt.config.ts`
 

--- a/docs/components/Hero.vue
+++ b/docs/components/Hero.vue
@@ -62,7 +62,7 @@ function generateIcons() {
         @click="copyToClipboard(($event.target as HTMLElement).innerText)"
       >
         <PhosphorIconCopy size="20" />
-        <code>pnpm add -D nuxt-phosphor-icons</code>
+        <code>npx nuxi@latest module add nuxt-phosphor-icons
       </button>
 
       <!-- Go to release notes -->

--- a/docs/components/Hero.vue
+++ b/docs/components/Hero.vue
@@ -62,7 +62,7 @@ function generateIcons() {
         @click="copyToClipboard(($event.target as HTMLElement).innerText)"
       >
         <PhosphorIconCopy size="20" />
-        <code>npx nuxi@latest module add nuxt-phosphor-icons
+        <code>npx nuxi@latest module add nuxt-phosphor-icons</code>
       </button>
 
       <!-- Go to release notes -->

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -14,7 +14,7 @@ Follow the following steps to start using this module:
 1. Add the `nuxt-phosphor-icons` module to your project as a `devDependency`
 
    ```bash
-   $ pnpm add -D nuxt-phosphor-icons
+   $ npx nuxi@latest module add nuxt-phosphor-icons
    ```
 
 2. Add the module to the `modules` section of the `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
